### PR TITLE
Allow transactionID to be set.

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -41,6 +41,7 @@ class PxPayAuthorizeRequest extends AbstractRequest
         $data->PxPayUserId = $this->getUsername();
         $data->PxPayKey = $this->getPassword();
         $data->TxnType = $this->action;
+        $data->TxnId = $this->getTransactionId();
         $data->AmountInput = $this->getAmount();
         $data->CurrencyInput = $this->getCurrency();
         $data->MerchantReference = $this->getDescription();

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -19,6 +19,11 @@ class Response extends AbstractResponse
         return empty($this->data->DpsTxnRef) ? null : (string) $this->data->DpsTxnRef;
     }
 
+    public function getTransactionId()
+    {
+        return empty($this->data->TxnId) ? null : (string) $this->data->TxnId;
+    }
+
     public function getCardReference()
     {
         if (! empty($this->data->Transaction->DpsBillingId)) {


### PR DESCRIPTION
This is per the discussion at https://github.com/thephpleague/omnipay/issues/261

transaction ID was discussed as the standardised way of referring to a unique ID generated by the merchant website
with transactionReference being the id generated by the gateway.

See code comments: https://github.com/eileenmcnaughton/nz.co.fuzion.omnipaymultiprocessor/blob/fece0e1bb7d1b4bacfd88b2fa63c7a87d0368580/vendor/omnipay/common/src/Omnipay/Common/Message/AbstractRequest.php#L405