### PR TITLE
Add TxnData fields to request

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -61,6 +61,7 @@ class PxPayAuthorizeRequest extends AbstractRequest
 
     /**
      * Set the PxPay PxPayKey
+     *
      * @param string $value
      * @return $this
      */
@@ -135,6 +136,7 @@ class PxPayAuthorizeRequest extends AbstractRequest
 
     /**
      * Set the TxnData3 field on the request
+     *
      * @param string $value Max 255 bytes
      * @return $this
      */

--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -7,32 +7,147 @@ use Omnipay\Common\Message\AbstractRequest;
 
 /**
  * PaymentExpress PxPay Authorize Request
+ *
+ * @link https://www.paymentexpress.com/Technical_Resources/Ecommerce_Hosted/PxPay_2_0
  */
 class PxPayAuthorizeRequest extends AbstractRequest
 {
+    /**
+     * PxPay Endpoint URL
+     *
+     * @var string URL
+     */
     protected $endpoint = 'https://sec.paymentexpress.com/pxaccess/pxpay.aspx';
+
+    /**
+     * PxPay TxnType
+     *
+     * @var string TxnType
+     */
     protected $action = 'Auth';
 
+    /**
+     * Get the PxPay PxPayUserId
+     *
+     * Unique username to identify customer account.
+     *
+     * @return mixed
+     */
     public function getUsername()
     {
         return $this->getParameter('username');
     }
 
+    /**
+     * Set the PxPay PxPayUserId
+     *
+     * @param string $value
+     * @return $this
+     */
     public function setUsername($value)
     {
         return $this->setParameter('username', $value);
     }
 
+    /**
+     * Get the PxPay PxPayKey
+     *
+     * @return mixed
+     */
     public function getPassword()
     {
         return $this->getParameter('password');
     }
 
+    /**
+     * Set the PxPay PxPayKey
+     * @param string $value
+     * @return $this
+     */
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
     }
 
+    /**
+     * Get the PxPay TxnData1
+     *
+     * Optional free text field that can be used to store information against a
+     * transaction. Returned in the response and can be retrieved from DPS
+     * reports.
+     *
+     * @return mixed
+     */
+    public function getTransactionData1()
+    {
+        return $this->getParameter('transactionData1');
+    }
+
+    /**
+     * Set the PxPay TxnData1
+     *
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setTransactionData1($value)
+    {
+        return $this->setParameter('transactionData1', $value);
+    }
+
+    /**
+     * Get the PxPay TxnData2
+     *
+     * Optional free text field that can be used to store information against a
+     * transaction. Returned in the response and can be retrieved from DPS
+     * reports.
+     *
+     * @return mixed
+     */
+    public function getTransactionData2()
+    {
+        return $this->getParameter('transactionData2');
+    }
+
+    /**
+     * Set the PxPay TxnData2
+     *
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setTransactionData2($value)
+    {
+        return $this->setParameter('transactionData2', $value);
+    }
+
+    /**
+     * Get the PxPay TxnData3
+     *
+     * Optional free text field that can be used to store information against a
+     * transaction. Returned in the response and can be retrieved from DPS
+     * reports.
+     *
+     * @return mixed
+     */
+    public function getTransactionData3()
+    {
+        return $this->getParameter('transactionData3');
+    }
+
+    /**
+     * Set the TxnData3 field on the request
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setTransactionData3($value)
+    {
+        return $this->setParameter('transactionData3', $value);
+    }
+
+    /**
+     * Get the transaction data
+     *
+     * @return SimpleXMLElement
+     */
     public function getData()
     {
         $this->validate('amount', 'returnUrl');
@@ -45,12 +160,21 @@ class PxPayAuthorizeRequest extends AbstractRequest
         $data->AmountInput = $this->getAmount();
         $data->CurrencyInput = $this->getCurrency();
         $data->MerchantReference = $this->getDescription();
+        $data->TxnData1 = $this->getTransactionData1();
+        $data->TxnData2 = $this->getTransactionData2();
+        $data->TxnData3 = $this->getTransactionData3();
         $data->UrlSuccess = $this->getReturnUrl();
         $data->UrlFail = $this->getReturnUrl();
 
         return $data;
     }
 
+    /**
+     * Send request
+     *
+     * @param  SimpleXMLElement $data
+     * @return Omnipay\PaymentExpress\Message\PxPayAuthorizeResponse
+     */
     public function sendData($data)
     {
         $httpResponse = $this->httpClient->post($this->endpoint, null, $data->asXML())->send();
@@ -58,6 +182,12 @@ class PxPayAuthorizeRequest extends AbstractRequest
         return $this->createResponse($httpResponse->xml());
     }
 
+    /**
+     * Create an authorize response
+     *
+     * @param  SimpleXMLElement $data
+     * @return Omnipay\PaymentExpress\Message\PxPayAuthorizeResponse
+     */
     protected function createResponse($data)
     {
         return $this->response = new PxPayAuthorizeResponse($this, $data);

--- a/tests/PxPayGatewayTest.php
+++ b/tests/PxPayGatewayTest.php
@@ -44,6 +44,32 @@ class PxPayGatewayTest extends GatewayTestCase
         $this->assertSame('Invalid Key', $response->getMessage());
     }
 
+    public function testAuthorizeWithTransactionDataSuccess()
+    {
+        $this->setMockHttpResponse('PxPayPurchaseSuccess.txt');
+
+        $options = array_merge($this->options, [
+            'transactionData1' => 'Business Name',
+            'transactionData2' => 'Business Phone',
+            'transactionData3' => 'Business ID',
+        ]);
+
+        $request = $this->gateway->authorize($options);
+
+        $this->assertSame($options['transactionData1'], $request->getTransactionData1());
+        $this->assertSame($options['transactionData2'], $request->getTransactionData2());
+        $this->assertSame($options['transactionData3'], $request->getTransactionData3());
+
+        $response = $request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getMessage());
+        $this->assertSame('https://sec.paymentexpress.com/pxpay/pxpay.aspx?userid=Developer&request=v5H7JrBTzH-4Whs__1iQnz4RGSb9qxRKNR4kIuDP8kIkQzIDiIob9GTIjw_9q_AdRiR47ViWGVx40uRMu52yz2mijT39YtGeO7cZWrL5rfnx0Mc4DltIHRnIUxy1EO1srkNpxaU8fT8_1xMMRmLa-8Fd9bT8Oq0BaWMxMquYa1hDNwvoGs1SJQOAJvyyKACvvwsbMCC2qJVyN0rlvwUoMtx6gGhvmk7ucEsPc_Cyr5kNl3qURnrLKxINnS0trdpU4kXPKOlmT6VacjzT1zuj_DnrsWAPFSFq-hGsow6GpKKciQ0V0aFbAqECN8rl_c-aZWFFy0gkfjnUM4qp6foS0KMopJlPzGAgMjV6qZ0WfleOT64c3E-FRLMP5V_-mILs8a', $response->getRedirectUrl());
+        $this->assertSame('GET', $response->getRedirectMethod());
+    }
+
     public function testPurchaseSuccess()
     {
         $this->setMockHttpResponse('PxPayPurchaseSuccess.txt');

--- a/tests/PxPayGatewayTest.php
+++ b/tests/PxPayGatewayTest.php
@@ -48,11 +48,11 @@ class PxPayGatewayTest extends GatewayTestCase
     {
         $this->setMockHttpResponse('PxPayPurchaseSuccess.txt');
 
-        $options = array_merge($this->options, [
+        $options = array_merge($this->options, array(
             'transactionData1' => 'Business Name',
             'transactionData2' => 'Business Phone',
             'transactionData3' => 'Business ID',
-        ]);
+        ));
 
         $request = $this->gateway->authorize($options);
 


### PR DESCRIPTION
Allow Auth/Purchase requests to pass TxnData1, TxnData2 and TxnData3 parameters.

Following discussion in https://github.com/thephpleague/omnipay-paymentexpress/pull/2

This is following the spec as detailed https://www.paymentexpress.com/Technical_Resources/Ecommerce_Hosted/PxPay_2_0#txndata