### PR TITLE
Set TxnId for pxPost, as per with pxPay

### DIFF
--- a/src/Message/PxPostAuthorizeRequest.php
+++ b/src/Message/PxPostAuthorizeRequest.php
@@ -50,6 +50,7 @@ class PxPostAuthorizeRequest extends AbstractRequest
         $data->InputCurrency = $this->getCurrency();
         $data->Amount = $this->getAmount();
         $data->MerchantReference = $this->getDescription();
+        $data->TxnId = $this->getTransactionId();
 
         if ($this->getCardReference()) {
             $data->DpsBillingId = $this->getCardReference();


### PR DESCRIPTION
The TxnId  parameter is currently being passed on for pxPay but not pxPost, this aligns them