### PR TITLE
Use pxPost for rebilling if all the details are present

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -70,6 +70,27 @@ class PxPayAuthorizeRequest extends AbstractRequest
         return $this->setParameter('password', $value);
     }
 
+    public function getPxPostUsername()
+    {
+        return $this->getParameter('pxPostUsername');
+    }
+
+    public function setPxPostUsername($value)
+    {
+        return $this->setParameter('pxPostUsername', $value);
+    }
+
+
+    public function getPxPostPassword()
+    {
+        return $this->getParameter('pxPostPassword');
+    }
+
+    public function setPxPostPassword($value)
+    {
+        return $this->setParameter('pxPostPassword', $value);
+    }
+
     /**
      * Get the PxPay TxnData1
      *

--- a/src/PxPayGateway.php
+++ b/src/PxPayGateway.php
@@ -6,6 +6,7 @@ use Omnipay\Common\AbstractGateway;
 use Omnipay\PaymentExpress\Message\PxPayAuthorizeRequest;
 use Omnipay\PaymentExpress\Message\PxPayCompleteAuthorizeRequest;
 use Omnipay\PaymentExpress\Message\PxPayPurchaseRequest;
+use Omnipay\Omnipay;
 
 /**
  * DPS PaymentExpress PxPay Gateway
@@ -22,6 +23,8 @@ class PxPayGateway extends AbstractGateway
         return array(
             'username' => '',
             'password' => '',
+            'pxPostUsername' => '',
+            'pxPostPassword' => '',
         );
     }
 
@@ -45,6 +48,27 @@ class PxPayGateway extends AbstractGateway
         return $this->setParameter('password', $value);
     }
 
+    public function getPxPostUsername()
+    {
+        return $this->getParameter('pxPostUsername');
+    }
+
+    public function setPxPostUsername($value)
+    {
+        return $this->setParameter('pxPostUsername', $value);
+    }
+
+
+    public function getPxPostPassword()
+    {
+        return $this->getParameter('pxPostPassword');
+    }
+
+    public function setPxPostPassword($value)
+    {
+        return $this->setParameter('pxPostPassword', $value);
+    }
+
     public function authorize(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PaymentExpress\Message\PxPayAuthorizeRequest', $parameters);
@@ -57,6 +81,12 @@ class PxPayGateway extends AbstractGateway
 
     public function purchase(array $parameters = array())
     {
+        if (!empty($parameters['cardReference']) && $this->getPxPostPassword() && $this->getPxPostUsername()) {
+            $gateway = Omnipay::create('PaymentExpress_PxPost');
+            $gateway->setPassword($this->getPxPostPassword());
+            $gateway->setUserName($this->getPxPostUsername());
+            return $gateway->purchase($parameters);
+        }
         return $this->createRequest('\Omnipay\PaymentExpress\Message\PxPayPurchaseRequest', $parameters);
     }
 


### PR DESCRIPTION
PxPay can create & rebill a token, but if you want to rebill it without access to the cvv code you need to use pxPost.

The calling code may support many processors & it should not need to handle the detail of redirecting to pxPost, instead the gateway
should use pxPost for rebilling if it has the pxPost credentials & cardReference available to it