### PR TITLE
Added support for enabling test mode

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -13,11 +13,18 @@ use Omnipay\Common\Message\AbstractRequest;
 class PxPayAuthorizeRequest extends AbstractRequest
 {
     /**
-     * PxPay Endpoint URL
+     * PxPay Live Endpoint URL
      *
      * @var string URL
      */
-    protected $endpoint = 'https://sec.paymentexpress.com/pxaccess/pxpay.aspx';
+    protected $liveEndpoint = 'https://sec.paymentexpress.com/pxaccess/pxpay.aspx';
+
+    /**
+     * PxPay test Endpoint URL
+     *
+     * @var string URL
+     */
+    protected $testEndpoint = 'https://uat.paymentexpress.com/pxaccess/pxpay.aspx';
 
     /**
      * PxPay TxnType
@@ -80,7 +87,6 @@ class PxPayAuthorizeRequest extends AbstractRequest
         return $this->setParameter('pxPostUsername', $value);
     }
 
-
     public function getPxPostPassword()
     {
         return $this->getParameter('pxPostPassword');
@@ -89,6 +95,11 @@ class PxPayAuthorizeRequest extends AbstractRequest
     public function setPxPostPassword($value)
     {
         return $this->setParameter('pxPostPassword', $value);
+    }
+
+    public function getEndpoint()
+    {
+        return $this->getTestMode() === true ? $this->testEndpoint : $this->liveEndpoint;
     }
 
     /**
@@ -204,7 +215,7 @@ class PxPayAuthorizeRequest extends AbstractRequest
      */
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->post($this->endpoint, null, $data->asXML())->send();
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, $data->asXML())->send();
 
         return $this->createResponse($httpResponse->xml());
     }

--- a/src/Message/PxPostAuthorizeRequest.php
+++ b/src/Message/PxPostAuthorizeRequest.php
@@ -9,7 +9,8 @@ use Omnipay\Common\Message\AbstractRequest;
  */
 class PxPostAuthorizeRequest extends AbstractRequest
 {
-    protected $endpoint = 'https://sec.paymentexpress.com/pxpost.aspx';
+    protected $liveEndpoint = 'https://sec.paymentexpress.com/pxpost.aspx';
+    protected $testEndpoint = 'https://uat.paymentexpress.com/pxpost.aspx';
     protected $action = 'Auth';
 
     public function getUsername()
@@ -30,6 +31,11 @@ class PxPostAuthorizeRequest extends AbstractRequest
     public function setPassword($value)
     {
         return $this->setParameter('password', $value);
+    }
+
+    public function getEndpoint()
+    {
+        return $this->getTestMode() === true ? $this->testEndpoint : $this->liveEndpoint;
     }
 
     /**
@@ -163,7 +169,7 @@ class PxPostAuthorizeRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->post($this->endpoint, null, $data->asXML())->send();
+        $httpResponse = $this->httpClient->post($this->getEndpoint(), null, $data->asXML())->send();
 
         return $this->response = new Response($this, $httpResponse->xml());
     }

--- a/src/PxPayGateway.php
+++ b/src/PxPayGateway.php
@@ -25,6 +25,7 @@ class PxPayGateway extends AbstractGateway
             'password' => '',
             'pxPostUsername' => '',
             'pxPostPassword' => '',
+            'testMode' => false,
         );
     }
 

--- a/src/PxPostGateway.php
+++ b/src/PxPostGateway.php
@@ -23,6 +23,7 @@ class PxPostGateway extends AbstractGateway
         return array(
             'username' => '',
             'password' => '',
+            'testMode' => false,
         );
     }
 

--- a/tests/PxPayGatewayTest.php
+++ b/tests/PxPayGatewayTest.php
@@ -226,4 +226,28 @@ class PxPayGatewayTest extends GatewayTestCase
 
         $response = $this->gateway->completePurchase($this->options)->send();
     }
+
+    public function testTestModeDisabled()
+    {
+        $options = array(
+            'testMode' => false
+        );
+
+        $request = $this->gateway->authorize($options);
+
+        $this->assertFalse($request->getTestMode());
+        $this->assertContains('sec.paymentexpress.com', $request->getEndpoint());
+    }
+
+    public function testTestModeEnabled()
+    {
+        $options = array(
+            'testMode' => true
+        );
+
+        $request = $this->gateway->authorize($options);
+
+        $this->assertTrue($request->getTestMode());
+        $this->assertContains('uat.paymentexpress.com', $request->getEndpoint());
+    }
 }

--- a/tests/PxPostGatewayTest.php
+++ b/tests/PxPostGatewayTest.php
@@ -119,4 +119,28 @@ class PxPostGatewayTest extends GatewayTestCase
         $this->assertNull($response->getCardReference());
         $this->assertSame('An Invalid Card Number was entered. Check the card number', $response->getMessage());
     }
+
+    public function testTestModeDisabled()
+    {
+        $options = array(
+            'testMode' => false
+        );
+
+        $request = $this->gateway->authorize($options);
+
+        $this->assertFalse($request->getTestMode());
+        $this->assertContains('sec.paymentexpress.com', $request->getEndpoint());
+    }
+
+    public function testTestModeEnabled()
+    {
+        $options = array(
+            'testMode' => true
+        );
+
+        $request = $this->gateway->authorize($options);
+
+        $this->assertTrue($request->getTestMode());
+        $this->assertContains('uat.paymentexpress.com', $request->getEndpoint());
+    }
 }


### PR DESCRIPTION
Payment Express requires a different endpoint for the test environment. Added support for enabling test mode through the parameters.

Fixes issue #23 