### PR TITLE
Provide improved error information when trxn_id is a duplicate.

### DIFF
--- a/src/Message/PxPayAuthorizeResponse.php
+++ b/src/Message/PxPayAuthorizeResponse.php
@@ -17,7 +17,7 @@ class PxPayAuthorizeResponse extends AbstractResponse implements RedirectRespons
 
     public function isRedirect()
     {
-        return 1 === (int) $this->data['valid'];
+        return ((1 === (int) $this->data['valid']) && !empty($this->data->URI));
     }
 
     public function getTransactionReference()
@@ -28,7 +28,7 @@ class PxPayAuthorizeResponse extends AbstractResponse implements RedirectRespons
     public function getMessage()
     {
         if (!$this->isRedirect()) {
-            return (string) $this->data->URI;
+            return $this->data->URI ? (string) $this->data->URI : (string) $this->data->ResponseText;
         }
     }
 


### PR DESCRIPTION
When the trxn_id is a duplicate PxPay returns ->valid but no URI which makes for super confusing debugging.

This patch changes the code to understand lack of a URI as meaning it can't be redirected & to return the error code in that case if queried. Payment Express advise you to just present a success screen to the user in this instance. But that is a decision for the calling library, not Omnipay.

Note if you use trxn_ids generated from your database and the same dev account across multiple DBs you are highly likely to hit a situation where it fails due to duplicate ids in your dev scenarios.