### PR TITLE
Run return URL through htmlentities

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -245,4 +245,14 @@ class PxPayAuthorizeRequest extends AbstractRequest
     {
         return $this->response = new PxPayAuthorizeResponse($this, $data);
     }
+
+    /**
+     * Get the request return URL.
+     *
+     * @return string
+     */
+    public function getReturnUrl()
+    {
+        return htmlentities($this->getParameter('returnUrl'));
+    }
 }


### PR DESCRIPTION
I originally thought this should be done by the calling function.

However as the calling function may call multiple processors and
some expect urls that have been run through html entities but
others will not cope with them I feel the decision needs to be
made by the gateway instead.