### PR TITLE
Add required currency for creating a credit card token

### DIFF
--- a/src/Message/PxPostCreateCardRequest.php
+++ b/src/Message/PxPostCreateCardRequest.php
@@ -13,6 +13,7 @@ class PxPostCreateCardRequest extends PxPostAuthorizeRequest
         $this->getCard()->validate();
 
         $data = $this->getBaseData();
+        $data->InputCurrency = $this->getCurrency();
         $data->Amount = '1.00';
         $data->EnableAddBillCard = 1;
         $data->CardNumber = $this->getCard()->getNumber();


### PR DESCRIPTION
Omitting the currency from the credit card token request fails if the currency defaults to the incorrect currency. In my case was defaulting to NZD and should be AUD. Specifying it clears up the issue.