### PR TITLE
Add receipt email parameter to allow receipts to be emailed from Payment Express

### DIFF
--- a/src/Message/PxPostAuthorizeRequest.php
+++ b/src/Message/PxPostAuthorizeRequest.php
@@ -39,6 +39,25 @@ class PxPostAuthorizeRequest extends AbstractRequest
     }
 
     /**
+     * @return mixed
+     */
+    public function getReceiptEmail()
+    {
+        return $this->getParameter('ReceiptEmail');
+    }
+
+    /**
+     * @param mixed $email
+     * @return $this
+     */
+    public function setReceiptEmail($email)
+    {
+        $this->setParameter('ReceiptEmail', $email);
+
+        return $this;
+    }
+
+    /**
      * Get the PxPost TxnData1
      *
      * Optional free text field that can be used to store information against a
@@ -162,6 +181,10 @@ class PxPostAuthorizeRequest extends AbstractRequest
         } else {
             // either cardReference or card is required
             $this->validate('card');
+        }
+
+        if ($this->getReceiptEmail()) {
+            $data->ReceiptEmail = $this->getReceiptEmail();
         }
 
         return $data;

--- a/src/PxPostGateway.php
+++ b/src/PxPostGateway.php
@@ -48,25 +48,6 @@ class PxPostGateway extends AbstractGateway
         return $this->setParameter('password', $value);
     }
 
-    /**
-     * @return mixed
-     */
-    public function getReceiptEmail()
-    {
-        return $this->getParameter('ReceiptEmail');
-    }
-
-    /**
-     * @param mixed $email
-     * @return $this
-     */
-    public function setReceiptEmail($email)
-    {
-        $this->setParameter('ReceiptEmail', $email);
-
-        return $this;
-    }
-
     public function authorize(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PaymentExpress\Message\PxPostAuthorizeRequest', $parameters);

--- a/src/PxPostGateway.php
+++ b/src/PxPostGateway.php
@@ -48,6 +48,25 @@ class PxPostGateway extends AbstractGateway
         return $this->setParameter('password', $value);
     }
 
+    /**
+     * @return mixed
+     */
+    public function getReceiptEmail()
+    {
+        return $this->getParameter('ReceiptEmail');
+    }
+
+    /**
+     * @param mixed $email
+     * @return $this
+     */
+    public function setReceiptEmail($email)
+    {
+        $this->setParameter('ReceiptEmail', $email);
+
+        return $this;
+    }
+
     public function authorize(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\PaymentExpress\Message\PxPostAuthorizeRequest', $parameters);


### PR DESCRIPTION
Payment Express has an option where a receipt can be sent from Payment Express to the customer, if an email address is supplied with the payment details.
This pull request adds that field so that receipts can be sent.

I am using this code on a live site so can confirm it is working well