### PR TITLE
Implement BillingId support

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -217,6 +217,8 @@ class PxPayAuthorizeRequest extends AbstractRequest
 
         if ($this->getCardReference()) {
             $data->DpsBillingId = $this->getCardReference();
+        } elseif ($this->getBillingId()) {
+            $data->BillingId = $this->getBillingId();
         }
 
         return $data;

--- a/src/Message/PxPostAuthorizeRequest.php
+++ b/src/Message/PxPostAuthorizeRequest.php
@@ -132,6 +132,30 @@ class PxPostAuthorizeRequest extends AbstractRequest
         return $this->setParameter('transactionData3', $value);
     }
 
+    /**
+     * Get the PxPost BillingId where this is used instead of the DpsBillingId
+     * for storing or retrieving a saved card profile.
+     *
+     * @see getCardReference() for DpsBillingId
+     * @return mixed
+     */
+    public function getBillingId()
+    {
+        return $this->getParameter('billingId');
+    }
+
+    /**
+     * Set a BillingId for use of a stored card with a local reference as an
+     * alternative to using cardReference (which uses DPS' generated reference instead)
+     *
+     * @param string $value Max 32 bytes
+     * @return $this
+     */
+    public function setBillingId($value)
+    {
+        return $this->setParameter('billingId', $value);
+    }
+
     protected function getBaseData()
     {
         $data = new \SimpleXMLElement('<Txn />');
@@ -172,6 +196,8 @@ class PxPostAuthorizeRequest extends AbstractRequest
 
         if ($this->getCardReference()) {
             $data->DpsBillingId = $this->getCardReference();
+        } elseif ($this->getBillingId()) {
+            $data->BillingId = $this->getBillingId();
         } elseif ($this->getCard()) {
             $this->getCard()->validate();
             $data->CardNumber = $this->getCard()->getNumber();


### PR DESCRIPTION
In some organisations card billing tokens are shared across systems and it's easier to use a local billing ID (like the customer number) instead of the DPS billing ID. This is explicitly supported by DPS through the BillingId parameter which the library can't currently handle, as the card reference is presumed to be the DpsBillingId.

I've implemented it as an alternative billingId parameter here, though it might be neater to continue to use cardReference with either an option to say that it's a BillingId, or a prefix on the reference to say so. That would be more in keeping with the Omnipay interface...

I haven't written tests for this yet, I thought I'd see whether this is the preferred approach first. Happy to write tests once we have a solid approach.