### PR TITLE
Remove explicit Guzzle dependency causing error

### DIFF
--- a/src/PxPayGateway.php
+++ b/src/PxPayGateway.php
@@ -2,7 +2,6 @@
 
 namespace Omnipay\PaymentExpress;
 
-use Guzzle\Http\Client as HttpClient;
 use Omnipay\Common\AbstractGateway;
 use Omnipay\PaymentExpress\Message\PxPayAuthorizeRequest;
 use Omnipay\PaymentExpress\Message\PxPayCompleteAuthorizeRequest;
@@ -105,25 +104,5 @@ class PxPayGateway extends AbstractGateway
     public function completeCreateCard(array $parameters = array())
     {
         return $this->completeAuthorize($parameters);
-    }
-
-    /**
-     * Force the default HTTP client to use TLS 1.2
-     *
-     * Note: using raw 6 instead of CURL_SSLVERSION_TLSv1_2 as the constant is PHP 5.5+
-     *
-     * @return HttpClient
-     */
-    protected function getDefaultHttpClient()
-    {
-        return new HttpClient(
-            '',
-            array(
-                'curl.options' => array(
-                    CURLOPT_CONNECTTIMEOUT => 60,
-                    CURLOPT_SSLVERSION => 6,
-                ),
-            )
-        );
     }
 }


### PR DESCRIPTION
Resolves #50 

Omnipay 3.0 removes explicit dependencies on Guzzle, so Guzzle classes are not necessarily available in all environments. Additionally, `getDefaultHttpClient` must now return an instance of Omnipay `ClientInterface`.