### PR TITLE
Align create card behaviour from PxPay to PxPost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "3.1.x-dev"
         }
     }
 }

--- a/src/Message/PxPostCreateCardRequest.php
+++ b/src/Message/PxPostCreateCardRequest.php
@@ -7,19 +7,32 @@ namespace Omnipay\PaymentExpress\Message;
  */
 class PxPostCreateCardRequest extends PxPostAuthorizeRequest
 {
+    public function getAction()
+    {
+        return $this->getParameter('action');
+    }
+
+    public function setAction($value)
+    {
+        return $this->setParameter('action', $value);
+    }
+
     public function getData()
     {
+        // don't use an existing card if we're trying to create a new one
+        $this->setCardReference(null);
+
         $this->validate('card');
         $this->getCard()->validate();
 
-        $data = $this->getBaseData();
-        $data->InputCurrency = $this->getCurrency();
-        $data->Amount = '1.00';
+        $this->setAmount($this->getAmount() ? $this->getAmount() : '1.00');
+
+        if ($this->getAction()) {
+            $this->action = $this->getAction();
+        }
+
+        $data = parent::getData();
         $data->EnableAddBillCard = 1;
-        $data->CardNumber = $this->getCard()->getNumber();
-        $data->CardHolderName = $this->getCard()->getName();
-        $data->DateExpiry = $this->getCard()->getExpiryDate('my');
-        $data->Cvc2 = $this->getCard()->getCvv();
 
         return $data;
     }


### PR DESCRIPTION
Adds support for:
* changing the amount authorized when creating a card
* changing the action used when creating a card (i.e. can be a Purchase)

Also adds some additional unit tests to increase the coverage a bit, and updates the master branch alias since we're now over v3.1.