### PR TITLE
Added some Getters/Setters & Callback Url to PxPay

### DIFF
--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -306,6 +306,10 @@ class PxPayAuthorizeRequest extends AbstractRequest
             $data->Timeout = $this->getTimeout();
         }
 
+        if ($this->getNotifyUrl()) {
+            $data->UrlCallback = $this->getNotifyUrl();
+        }
+
         if ($this->getDescription()) {
             $data->MerchantReference = $this->getDescription();
         }

--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -2,8 +2,8 @@
 
 namespace Omnipay\PaymentExpress\Message;
 
-use SimpleXMLElement;
 use Omnipay\Common\Message\AbstractRequest;
+use SimpleXMLElement;
 
 /**
  * PaymentExpress PxPay Authorize Request
@@ -100,6 +100,59 @@ class PxPayAuthorizeRequest extends AbstractRequest
     public function getEndpoint()
     {
         return $this->getTestMode() === true ? $this->testEndpoint : $this->liveEndpoint;
+    }
+
+    /**
+     * Get the PxPay EmailAddress
+     *
+     * Optional: The EmailAddress field can be used to store a customer's email address and will be returned in the
+     * transaction response. The response data along with the email address can then be used by the merchant
+     * to generate a notification/receipt email for the customer.
+     *
+     * @return mixed
+     */
+    public function getEmailAddress()
+    {
+        return $this->getParameter('emailAddress');
+    }
+
+    /**
+     * Set the PxPay EmailAddress
+     *
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setEmailAddress($value)
+    {
+        return $this->setParameter('emailAddress', $value);
+    }
+
+    /**
+     * A timeout (TO) can be set for the hosted payments page, after which the payment page will
+     * timeout and no longer allow a payment to be taken. Note: The default timeout of the created hosted
+     * payment page session is 72 hours. A specific timeout timestamp can also be specified via the request in
+     * Coordinated Universal Time (UTC). The value must be in the format "TO=yymmddHHmm" 
+     * e.g.“TO=1010142221” for 2010 October 14th 10:21pm.
+     * The merchant should submit the timeout value of when the payment page should timeout. One approach
+     * is to find the time (UTC) from when the GenerateRequest input XML document is generated and add on
+     * how much time you wish to give the customer before the payment page times out.
+     *
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setTimeout($value)
+    {
+        return $this->setParameter('timeout', $value);
+    }
+
+    /**
+     * Get the PxPay Timeout
+     *
+     * @return string
+     */
+    public function getTimeout()
+    {
+        return $this->getParameter('timeout');
     }
 
     /**
@@ -244,6 +297,14 @@ class PxPayAuthorizeRequest extends AbstractRequest
         $data->CurrencyInput = $this->getCurrency();
         $data->UrlSuccess = $this->getReturnUrl();
         $data->UrlFail = $this->getCancelUrl() ?: $this->getReturnUrl();
+
+        if ($this->getEmailAddress()) {
+            $data->EmailAddress = $this->getEmailAddress();
+        }
+
+        if ($this->getTimeout()) {
+            $data->Timeout = $this->getTimeout();
+        }
 
         if ($this->getDescription()) {
             $data->MerchantReference = $this->getDescription();

--- a/src/Message/PxPayAuthorizeRequest.php
+++ b/src/Message/PxPayAuthorizeRequest.php
@@ -128,6 +128,30 @@ class PxPayAuthorizeRequest extends AbstractRequest
     }
 
     /**
+     * Get the PxPay PhoneNumber
+     *
+     * Optional: The PhoneNumber field can be used to store a customer's phone number and will be returned in the
+     * transaction response. This field may be used for transaction verification purposes.
+     *
+     * @return mixed
+     */
+    public function getPhoneNumber()
+    {
+        return $this->getParameter('phoneNumber');
+    }
+
+    /**
+     * Set the PxPay PhoneNumber
+     *
+     * @param string $value Max 255 bytes
+     * @return $this
+     */
+    public function setPhoneNumber($value)
+    {
+        return $this->setParameter('phoneNumber', $value);
+    }
+
+    /**
      * A timeout (TO) can be set for the hosted payments page, after which the payment page will
      * timeout and no longer allow a payment to be taken. Note: The default timeout of the created hosted
      * payment page session is 72 hours. A specific timeout timestamp can also be specified via the request in
@@ -279,7 +303,6 @@ class PxPayAuthorizeRequest extends AbstractRequest
         return $this->setParameter('forcePaymentMethod', $value);
     }
 
-
     /**
      * Get the transaction data
      *
@@ -300,6 +323,10 @@ class PxPayAuthorizeRequest extends AbstractRequest
 
         if ($this->getEmailAddress()) {
             $data->EmailAddress = $this->getEmailAddress();
+        }
+
+        if ($this->getPhoneNumber()) {
+            $data->PhoneNumber = $this->getPhoneNumber();
         }
 
         if ($this->getTimeout()) {

--- a/src/PxPayGateway.php
+++ b/src/PxPayGateway.php
@@ -3,10 +3,10 @@
 namespace Omnipay\PaymentExpress;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\Omnipay;
 use Omnipay\PaymentExpress\Message\PxPayAuthorizeRequest;
 use Omnipay\PaymentExpress\Message\PxPayCompleteAuthorizeRequest;
 use Omnipay\PaymentExpress\Message\PxPayPurchaseRequest;
-use Omnipay\Omnipay;
 
 /**
  * DPS Windcave PxPay Gateway
@@ -58,7 +58,6 @@ class PxPayGateway extends AbstractGateway
     {
         return $this->setParameter('pxPostUsername', $value);
     }
-
 
     public function getPxPostPassword()
     {


### PR DESCRIPTION
This PR adds support for the `get/setNotifyUrl()` `get/setEMailAddress()` `get/setTimeout()` properties for PXPay.

The main one being the notify url - which enables usage of Windcaves `HPP & FPRN` (callback) feature. 
Kind of important really 😄.